### PR TITLE
Adds automated horizontal scrollbars to tables of times to handle ove…

### DIFF
--- a/css/Default.css
+++ b/css/Default.css
@@ -45,6 +45,8 @@ table.times {
   border-style: solid;
   border-color: #000000;
   background-color: #303030;
+  max-width: 720px;
+  overflow-x: auto;
 }
 th.times {
   border-style: dotted;


### PR DESCRIPTION
…rflow

Team EE has exposed that elmastats does not have handling for when tables of times exceed the expected maximum-width of the page. 

Though EE is currently the only example that is breaking, other teams are not far off and in theory we may choose to later add further functionality that does this too.

This commit adjusts the CSS of the table class across the board to automagically handle horizontal scrollbars rather than breaking.